### PR TITLE
Feat: Implement column inclusion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ json-to-excel-converter INPUT.json OUTPUT.(csv|xlsx) \
   --sample-headers 10 \
   --header-order stable \
   --first-column id \
-  --exclude details
+  --exclude details \
+  --include summary \
+  --include details
 ```
 
 ### Options
@@ -77,6 +79,7 @@ json-to-excel-converter INPUT.json OUTPUT.(csv|xlsx) \
 - `--header-order`: column ordering `stable` (first-seen) or `alpha` (alphabetical)
 - `--first-column`: pin specific columns to the beginning (repeatable)
 - `--exclude`: remove columns by path prefix (repeatable)
+- `--include`: keep only columns whose path equals or starts with this prefix (repeatable). Ordering of groups follows the flag order; pinned columns still appear first. Within each group, `--header-order` applies.
 
 ## FAQ
 
@@ -162,6 +165,16 @@ json-to-excel-converter your-data.json output.csv --root products --first-column
 
 # Remove unwanted columns
 json-to-excel-converter your-data.json output.csv --exclude personal_info --exclude internal
+
+### 7. Include Only Certain Columns (and Order by Flag Order)
+```bash
+json-to-excel-converter sample.json selected.csv \
+  --root orders \
+  --first-column order_id \
+  --include payment \
+  --include customer
+```
+What you get: only `order_id`, then all `payment.*` columns, then all `customer.*` columns. Within each group, ordering follows `--header-order`.
 ```
 
 ### Row Count Summary

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,6 +21,7 @@
 - **Sampling**: Tool reads first `--sample-headers` rows (default: 1000) to discover all possible columns
 - **Ordering**: `--header-order stable` (first-seen) vs `--header-order alpha` (alphabetical)
 - **Pinning**: `--first-column id --first-column name` puts these columns first
+- **Including**: `--include prefix` keeps only matching columns. When multiple are provided, groups are ordered by flag order; within each group, `--header-order` applies.
 
 ### Troubleshooting
 

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -7,9 +7,11 @@
    - If `--explode path` is used, create one row per element at `path` (cartesian product across multiple paths).
    - Otherwise, join scalar lists with `--list-sep` when `--list-policy join` (default), or JSON-encode them when `--list-policy json`.
 4. Apply exclusion: drop keys whose dotted name equals or starts with any `--exclude` prefix.
+5. Optionally apply inclusion: if `--include` is provided, retain only keys matching any prefix (plus any pinned `--first-column`).
 5. Build headers from a sample window (`--sample-headers`, default 1000):
    - Pin columns from `--first-column` in the given order.
    - Order remaining columns via `--header-order stable|alpha`.
+   - If `--include` is provided, group remaining headers by the order of include prefixes, preserving group-internal order per `--header-order`.
 6. Write rows to CSV or XLSX with type normalization (e.g., safe conversion of Decimal).
 
 ### Deterministic header behavior

--- a/examples/commands.md
+++ b/examples/commands.md
@@ -19,6 +19,13 @@ json-to-excel-converter sample.json clean.csv --root orders --exclude customer.a
 
 # Excel with custom sheet
 json-to-excel-converter sample.json orders.xlsx --root orders --sheet-name "Orders"
+
+# Include selected columns and order groups
+json-to-excel-converter sample.json selected.csv \
+  --root orders \
+  --first-column order_id \
+  --include payment \
+  --include customer
 ```
 
 ## Development Examples (using sample data)

--- a/tests/cli/test_cli_csv.py
+++ b/tests/cli/test_cli_csv.py
@@ -36,3 +36,62 @@ def test_csv_exclude(tmp_path: Path):
     header = dst.read_text(encoding="utf-8").splitlines()[0]
     cols = header.split(",")
     assert not any(c.startswith("details.") for c in cols)
+
+
+def test_csv_include_and_order(tmp_path: Path):
+    runner = CliRunner()
+    src = project_root() / "examples" / "ads_small.json"
+    dst = tmp_path / "out.csv"
+
+    # Include summary first, then details; pin id first
+    result = runner.invoke(
+        app,
+        [
+            str(src),
+            str(dst),
+            "--root",
+            "items",
+            "--first-column",
+            "id",
+            "--include",
+            "summary",
+            "--include",
+            "details",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    header = dst.read_text(encoding="utf-8").splitlines()[0]
+    cols = header.split(",")
+    # id must be first
+    assert cols[0] == "id"
+    # All columns should be from summary.* or details.* (and id)
+    assert all(c == "id" or c.startswith("summary.") or c.startswith("details.") for c in cols)
+    # The first non-pinned column should come from the first include prefix (summary)
+    assert cols[1].startswith("summary.")
+
+
+def test_csv_include_and_exclude(tmp_path: Path):
+    runner = CliRunner()
+    src = project_root() / "examples" / "ads_small.json"
+    dst = tmp_path / "out.csv"
+
+    result = runner.invoke(
+        app,
+        [
+            str(src),
+            str(dst),
+            "--root",
+            "items",
+            "--include",
+            "summary",
+            "--exclude",
+            "summary.internal",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    header = dst.read_text(encoding="utf-8").splitlines()[0]
+    cols = header.split(",")
+    # No details.* columns should be present
+    assert not any(c.startswith("details.") for c in cols)
+    # Exclusion of a subset under summary should be respected
+    assert not any(c.startswith("summary.internal") for c in cols)

--- a/tests/cli/test_cli_xlsx.py
+++ b/tests/cli/test_cli_xlsx.py
@@ -26,3 +26,34 @@ def test_xlsx_basic(tmp_path: Path):
     header = [c.value for c in next(ws.iter_rows(max_row=1))]
     assert header[0] == "id"
     assert any(str(c).startswith("summary.") for c in header)
+
+
+def test_xlsx_include_and_order(tmp_path: Path):
+    runner = CliRunner()
+    src = project_root() / "examples" / "ads_small.json"
+    dst = tmp_path / "out.xlsx"
+
+    result = runner.invoke(
+        app,
+        [
+            str(src),
+            str(dst),
+            "--root",
+            "items",
+            "--sheet-name",
+            "Items",
+            "--first-column",
+            "id",
+            "--include",
+            "summary",
+            "--include",
+            "details",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    wb = openpyxl.load_workbook(dst)
+    ws = wb.active
+    header = [c.value for c in next(ws.iter_rows(max_row=1))]
+    assert header[0] == "id"
+    assert all(c == "id" or str(c).startswith("summary.") or str(c).startswith("details.") for c in header)
+    assert str(header[1]).startswith("summary.")


### PR DESCRIPTION
- Added `--include` option to retain only columns matching specified prefixes.
- Enhanced header collection to reorder based on include prefixes while preserving pinned columns.
- Updated documentation in README.md, guide.md, and tech.md to reflect new functionality.
- Added tests for inclusion and ordering in both CSV and XLSX outputs.